### PR TITLE
Multiline comment fix

### DIFF
--- a/jstyleson.py
+++ b/jstyleson.py
@@ -37,6 +37,10 @@ def dispose(json_str):
                 normal = True
                 continue
 
+        if a_step_from_comment_away:  # We have just met a '*'
+            if char != '/':
+                a_step_from_comment_away = False
+
         if char == '"':
             if normal and not escaped:
                 # We are now in a string

--- a/tests/jstyleson_test.py
+++ b/tests/jstyleson_test.py
@@ -18,6 +18,7 @@ json_test_case = """
     /*multi
     line
     "comment with many "quotes"quotes"quotes"
+    * followed sometime after by a / but that does not end the comment
     */
     "object": {
         "key": "中文"


### PR DESCRIPTION
Added fix and test case for previous bug where a closing comment was incorrectly identified by a slash following an asterisk, even if separated by other characters.