### PR TITLE
Handeling single line comment as the last line of json

### DIFF
--- a/jstyleson.py
+++ b/jstyleson.py
@@ -95,6 +95,13 @@ def dispose(json_str):
             if normal:
                 _remove_last_comma(result_str, index)
 
+    #  To remove single line comment which is the last line of json
+    if sl_comment:
+        sl_comment = False
+        normal = True
+        for i in range(former_index, len(json_str)):
+            result_str[i] = ""
+
     # Show respect to original input if we are in python2
     return ("" if isinstance(json_str, str) else u"").join(result_str)
 

--- a/tests/jstyleson_test.py
+++ b/tests/jstyleson_test.py
@@ -33,7 +33,7 @@ json_test_case = """
     }
     //comment with 中文
 }
-"""
+//comment without newline character"""
 
 json_expected = {
     "string": "string",


### PR DESCRIPTION
If a single line comment is the last line, then there is **no** \n to remove the comment.
This PR makes sure that this case is handled.